### PR TITLE
Add support for ADC in espulp

### DIFF
--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -188,16 +188,16 @@ msgstr ""
 msgid "%q must be >= %d"
 msgstr ""
 
-#: ports/espressif/common-hal/analogbufio/BufferedIn.c
-msgid "%q must be array of type 'H'"
-msgstr ""
-
 #: shared-bindings/analogbufio/BufferedIn.c
 msgid "%q must be a bytearray or array of type 'H' or 'B'"
 msgstr ""
 
 #: shared-bindings/audiocore/RawSample.c
 msgid "%q must be a bytearray or array of type 'h', 'H', 'b', or 'B'"
+msgstr ""
+
+#: ports/espressif/common-hal/analogbufio/BufferedIn.c
+msgid "%q must be array of type 'H'"
 msgstr ""
 
 #: ports/raspberrypi/bindings/cyw43/__init__.c py/argcheck.c py/objexcept.c
@@ -416,10 +416,6 @@ msgstr ""
 #: ports/atmel-samd/common-hal/countio/Counter.c
 #: ports/atmel-samd/common-hal/rotaryio/IncrementalEncoder.c
 msgid "A hardware interrupt channel is already in use"
-msgstr ""
-
-#: ports/espressif/common-hal/analogio/AnalogIn.c
-msgid "ADC2 is being used by WiFi"
 msgstr ""
 
 #: shared-bindings/_bleio/Address.c shared-bindings/ipaddress/IPv4Address.c
@@ -1229,7 +1225,8 @@ msgstr ""
 msgid "Interrupt error."
 msgstr ""
 
-#: py/argcheck.c shared-bindings/digitalio/DigitalInOut.c
+#: ports/mimxrt10xx/common-hal/pwmio/PWMOut.c py/argcheck.c
+#: shared-bindings/digitalio/DigitalInOut.c
 #: shared-bindings/displayio/EPaperDisplay.c
 msgid "Invalid %q"
 msgstr ""
@@ -1521,10 +1518,6 @@ msgstr ""
 
 #: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
 msgid "No in or out in program"
-msgstr ""
-
-#: shared-bindings/aesio/aes.c
-msgid "No key was specified"
 msgstr ""
 
 #: shared-bindings/time/__init__.c
@@ -3044,8 +3037,8 @@ msgid "extra positional arguments given"
 msgstr ""
 
 #: shared-bindings/audiocore/WaveFile.c shared-bindings/audiomp3/MP3Decoder.c
-#: shared-bindings/displayio/OnDiskBitmap.c shared-bindings/synthio/__init__.c
-#: shared-module/gifio/GifWriter.c
+#: shared-bindings/displayio/OnDiskBitmap.c shared-bindings/gifio/OnDiskGif.c
+#: shared-bindings/synthio/__init__.c shared-module/gifio/GifWriter.c
 msgid "file must be a file opened in byte mode"
 msgstr ""
 

--- a/ports/espressif/CMakeLists.txt
+++ b/ports/espressif/CMakeLists.txt
@@ -5,7 +5,7 @@ cmake_minimum_required(VERSION 3.16)
 set(ENV{IDF_PATH} ${CMAKE_SOURCE_DIR}/esp-idf)
 
 # The component list here determines what options we get in menuconfig and what the ninja file can build.
-set(COMPONENTS bt driver esp-tls esp_adc_cal esp_event esp_netif esp_psram esp_wifi esptool_py freertos log lwip main mbedtls mdns soc ulp usb wpa_supplicant)
+set(COMPONENTS bt driver esp-tls esp_adc esp_adc_cal esp_event esp_netif esp_psram esp_wifi esptool_py freertos log lwip main mbedtls mdns soc ulp usb wpa_supplicant)
 set(EXTRA_COMPONENT_DIRS esp-protocols/components/mdns)
 
 if("${CIRCUITPY_ESPCAMERA}")

--- a/ports/espressif/Makefile
+++ b/ports/espressif/Makefile
@@ -68,7 +68,8 @@ INC += \
 	-isystem esp-idf/components/efuse/include \
 	-isystem esp-idf/components/efuse/$(IDF_TARGET)/include \
 	-isystem esp-idf/components/$(IDF_TARGET)/include \
-	-isystem esp-idf/components/esp_adc/deprecated/include \
+	-isystem esp-idf/components/esp_adc/include \
+	-isystem esp-idf/components/esp_adc/$(IDF_TARGET)/include \
 	-isystem esp-idf/components/esp_app_format/include \
 	-isystem esp-idf/components/esp_common/include \
 	-isystem esp-idf/components/esp_event/include \

--- a/ports/espressif/bindings/espulp/ULP.h
+++ b/ports/espressif/bindings/espulp/ULP.h
@@ -29,11 +29,13 @@
 #include "py/obj.h"
 #include "common-hal/espulp/ULP.h"
 
+#include "shared-bindings/microcontroller/Pin.h"
+
 extern const mp_obj_type_t espulp_ulp_type;
 
 void common_hal_espulp_ulp_construct(espulp_ulp_obj_t *self, espulp_architecture_t arch);
 bool common_hal_espulp_ulp_deinited(espulp_ulp_obj_t *self);
 void common_hal_espulp_ulp_deinit(espulp_ulp_obj_t *self);
 
-void common_hal_espulp_ulp_run(espulp_ulp_obj_t *self, uint32_t *program, size_t length, uint32_t pin_mask);
+void common_hal_espulp_ulp_run(espulp_ulp_obj_t *self, uint32_t *program, size_t length, uint32_t pin_mask, const mcu_pin_obj_t *adc_pin);
 void common_hal_espulp_ulp_halt(espulp_ulp_obj_t *self);

--- a/ports/espressif/common-hal/analogio/AnalogIn.c
+++ b/ports/espressif/common-hal/analogio/AnalogIn.c
@@ -39,20 +39,8 @@
 
 #include <string.h>
 
-#define DEFAULT_VREF        1100
-#define NO_OF_SAMPLES       2
-#define ATTENUATION         ADC_ATTEN_DB_11
-#if defined(CONFIG_IDF_TARGET_ESP32)
-#define DATA_WIDTH          ADC_WIDTH_BIT_12
-#elif defined(CONFIG_IDF_TARGET_ESP32C3)
-#define DATA_WIDTH          ADC_WIDTH_BIT_12
-#elif defined(CONFIG_IDF_TARGET_ESP32S2)
-#define DATA_WIDTH          ADC_WIDTH_BIT_13
-#elif defined(CONFIG_IDF_TARGET_ESP32S3)
-#define DATA_WIDTH          ADC_WIDTH_BIT_12
-#else
-#error No known CONFIG_IDF_TARGET_xxx found
-#endif
+#define DEFAULT_VREF 1100
+#define NO_OF_SAMPLES 2
 
 void common_hal_analogio_analogin_construct(analogio_analogin_obj_t *self,
     const mcu_pin_obj_t *pin) {

--- a/ports/espressif/common-hal/analogio/AnalogIn.h
+++ b/ports/espressif/common-hal/analogio/AnalogIn.h
@@ -34,7 +34,21 @@
 #include "freertos/semphr.h"
 #include "py/obj.h"
 
-typedef struct {
+#define ATTENUATION ADC_ATTEN_DB_11
+#if defined(CONFIG_IDF_TARGET_ESP32)
+#define DATA_WIDTH ADC_BITWIDTH_12
+#elif defined(CONFIG_IDF_TARGET_ESP32C3)
+#define DATA_WIDTH ADC_BITWIDTH_12
+#elif defined(CONFIG_IDF_TARGET_ESP32S2)
+#define DATA_WIDTH ADC_BITWIDTH_13
+#elif defined(CONFIG_IDF_TARGET_ESP32S3)
+#define DATA_WIDTH ADC_BITWIDTH_12
+#else
+#error No known CONFIG_IDF_TARGET_xxx found
+#endif
+
+typedef struct
+{
     mp_obj_base_t base;
     const mcu_pin_obj_t *pin;
 } analogio_analogin_obj_t;

--- a/ports/espressif/peripherals/pins.h
+++ b/ports/espressif/peripherals/pins.h
@@ -49,7 +49,7 @@ extern const mp_obj_type_t mcu_pin_type;
 
 #define NO_PIN (GPIO_NUM_NC)
 
-#define NO_ADC 0
+#define NO_ADC -1
 #define NO_ADC_CHANNEL SOC_ADC_MAX_CHANNEL_NUM
 
 #define NO_TOUCH_CHANNEL TOUCH_PAD_MAX


### PR DESCRIPTION
This PR adds support for ADC reads in the ULP by way of passing `adc_pin` to `ULP.run` (Closes https://github.com/adafruit/circuitpython/issues/7740).

Builds off of https://github.com/adafruit/circuitpython/pull/6913

I'm successfully reading 13 bits of resolution with the following code:

```python
import board
import espulp
import minielf
import memorymap

class ULP:
    def __init__(self):
        elf = minielf.ELFFile(open("/ulp.bin", "rb"))
        code_header = elf.get_header_by_type(minielf.PT_LOAD)
        self.__code = bytes(elf.pread(code_header.p_offset, code_header.p_filesz))
        self.__program = espulp.ULP(espulp.Architecture.RISCV)
        self.__symtab = elf.get_section_by_name('.symtab')
        self.__memory_map = memorymap.AddressRange(start=0x50000000, length=0x2000)

        self.alarm = espulp.ULPAlarm(self.__program)

        self.shared_memory = {
            'adc_value': self.__get_uint16('adc_value')
        }

    def start(self):
        self.__program.halt()
        self.__program.run(self.__code, adc_pin=board.A10)

    def __get_symbol(self, name):
        sy = self.__symtab.get_first_symbol_by_name(name)
        if sy is None:
            raise ValueError(f'No symbol named "{name}"')
        return sy.entry.st_value
    
    def __get_uint16(self, name):
        output = 0
        for i in range(2):
            symbol = self.__get_symbol(f'{name}0x0{i}')
            byte = self.__memory_map[symbol]
            output |= byte << (i * 8)
        return output
```

```c
#include "ulp_riscv.h"
#include "ulp_riscv_adc_ulp_core.h"
#include "ulp_riscv_utils.h"
#include "ulp_riscv_gpio.h"

EXPORT volatile uint8_t adc_value0x00;
EXPORT volatile uint8_t adc_value0x01;

void convert_uint16_to_uint8(uint32_t input, uint8_t bytes[2])
{
    for (int i = 0; i < 2; i++)
    {
        bytes[i] = (input >> (i * 8)) & 0xff;
    }
}

int main(void)
{
    uint16_t value = ulp_riscv_adc_read_channel(ADC_UNIT_1, ADC_CHANNEL_0);
    uint8_t bytes[2];
    convert_uint16_to_uint8(value, bytes);
    adc_value0x00 = bytes[0];
    adc_value0x01 = bytes[1];

    ulp_riscv_wakeup_main_processor();

    return 0;
}
```


